### PR TITLE
Documentation fix. Documentation was not rendered properly

### DIFF
--- a/src/asciidoc/data_parallelism.adoc
+++ b/src/asciidoc/data_parallelism.adoc
@@ -655,8 +655,8 @@ accumulator = {ShoppingCart cart, Item value -> cart.addItem(value)} initialValu
 ----
 
 The return type is a map.
-E.g. [['he', 1], ['she', 2], ['he', 2], ['me', 1], ['she', 5], ['he', 1] with the initial value provided a 0 will be combined into
-['he' : 4, 'she' : 7, 'he', : 2, 'me' : 1]
+E.g. [['he', 1], ['she', 2], ['he', 2], ['me', 1], ['she', 5], ['he', 1]] with the initial value provided a 0
+will be combined into ['he' : 4, 'she' : 7, 'me' : 1]
 
 ****
 The keys will be mutually compared using their equals and hashCode methods. Consider using _\@Canonical_ or _\@EqualsAndHashCode_

--- a/src/asciidoc/dataflow.adoc
+++ b/src/asciidoc/dataflow.adoc
@@ -2179,7 +2179,7 @@ op3.join()
 Shutting down the whole JVM through _System.exit()_ will also obviously shutdown the dataflow network, however, no lifecycle listeners will be invoked in such cases.
 ****
 
-===== Stopping operators gently
+==== Stopping operators gently
 
 Operators handle incoming messages repeatedly. The only safe moment for stopping an operator without the
 risk of loosing any messages is right after the operator has finished processing messages and is just about
@@ -2906,7 +2906,8 @@ the _doubler_ actor.
 
 The _DataflowVariable_ as well as the _DataflowQueue_ classes can obviously be used from any thread of your
 application, not only from the tasks created by _Dataflow.task()_ . Consider the following example:
-----import groovyx.gpars.dataflow.DataflowVariable
+----
+import groovyx.gpars.dataflow.DataflowVariable
 
 final DataflowVariable a = new DataflowVariable<String>()
 final DataflowVariable b = new DataflowVariable<String>()


### PR DESCRIPTION
I noticed that documentation does not render properly and fixed it. Line starting from [ was interpreted as ASCIIDoc syntax and there was missing line break and a section nesting problem.

Note that the example was wrong. Key 'he' appeared twice - second time followed by comma, which suggests it was a typo.
