### PR TITLE
AsciiDoc suggestions

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,18 +1,27 @@
-image::gpars-rgb.svg[Logo, 250, float="right"]
-
-= The GPars Guide
+= The GPars Guide image:gpars-rgb.svg[Logo,200,float=right]
 
 :leveloffset: 1
 
 include::introduction.adoc[]
+
 include::getting_started.adoc[]
+
 include::data_parallelism.adoc[]
+
 include::groovy_csp.adoc[]
+
 include::actors.adoc[]
+
 include::agents.adoc[]
+
 include::dataflow.adoc[]
+
 include::stm.adoc[]
+
 include::google_app_engine_integration.adoc[]
+
 include::tips.adoc[]
+
 include::remoting.adoc[]
+
 include::conclusion.adoc[]


### PR DESCRIPTION
- put logo in document title
- use blank lines between chapter includes

Note that technically we shouldn't be mixing content and presentation by putting the logo image explicitly in the document. Instead, it's best to define an attribute for the logo and then use the converter to place it in the generated HTML output. For instance:

```
= The GPars Guide
:title-logo: gpars-rgb.svg
```

If you want the logo to display when rendered on GitHub, then you can use a preprocessor conditional _below_ the document title, such as:

```
ifdef::env-github[]
image::images/gpars-rgb.svg[Logo,200]
```
