### PR TITLE
Updated build to publish snapshots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ plugins {
 
 apply plugin: 'groovy'
 apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'osgi'
 apply plugin: 'eclipse'
 apply plugin: 'idea'
@@ -295,6 +296,34 @@ task zipDist(type: Zip) {
     appendix = 'all'
 }
 
+publishing {
+    publications {
+        gParsPublish(MavenPublication) {
+            artifactId 'gpars'
+            from components.java
+
+            artifact jarDoc {
+                classifier = 'javadoc'
+            }
+            artifact jarSrc {
+                classifier = 'sources'
+            }
+            artifact zipGuide {
+                classifier = 'guide'
+            }
+            artifact zipSamples {
+                classifier = 'samples'
+            }
+            artifact zipJavaDemo {
+                classifier = 'mvn-java-demo'
+            }
+            artifact zipDist {
+                classifier = 'all'
+            }
+        }
+    }
+}
+
 // TODO: What is the bintray organisation (will it be part of groovy)
 // TODO: Activate signing to bintray
 // TODO: Activate sync to Maven Central
@@ -349,6 +378,8 @@ artifactory {
 }
 
 artifactoryPublish {
+    dependsOn 'generatePomFileForGParsPublishPublication'
+    publications(publishing.publications.gParsPublish)
     onlyIf{project.properties.gpars_bintrayUser && project.properties.gpars_bintrayKey && version.contains('SNAPSHOT')}
 }
 


### PR DESCRIPTION
Publishing snapshot to oss.jfrog.org.
Modification summary:
* Using the new Gradle Maven publish plugin
* Added the Maven publish configuration to the Artifactory publish configuration
* Additional module artifacts are assigned with classifiers instead appendixes. There seems to be no support for appendixes in the new Maven publish plugin


TBD: Add the artifactoryPublish task to the CI server configuration files and supply the CI server with the Bintray credentials for Gradle.